### PR TITLE
Write out to a env file so we can pull it into docker

### DIFF
--- a/assume_profile
+++ b/assume_profile
@@ -233,7 +233,15 @@ if [ -n "$role_arn" ]; then
   cleanup
 
   AWS_ACCESS_KEY_ID=${ACCESS_KEY} AWS_SECRET_ACCESS_KEY=${SECRET_KEY} AWS_SESSION_TOKEN=${SESSION_TOKEN} bash -c ${CMD}
-  exit 0
+
+  # Write out so we can pull this into docker e.g. env_file
+  cat > ".aws.creds.env" <<- EOM
+AWS_ACCESS_KEY_ID=${ACCESS_KEY}
+AWS_SECRET_ACCESS_KEY=${SECRET_KEY}
+AWS_SESSION_TOKEN=${SESSION_TOKEN}
+EOM
+
+    exit 0
 else
   cleanup
 


### PR DESCRIPTION
Need a way to pull the credentials easily into docker or docker-compose e.g. using the env_file option. So write out a file with the credentials that we can then use in docker.
